### PR TITLE
templates file created for side effect actions

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,8 @@ import Header from "@/components/Header";
 import ThemeProvider from "@/components/theme/ThemeProvider";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
 import { Toaster } from "sonner";
+import "./globals.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -1,0 +1,15 @@
+import RedirectToast from "@/components/RedirectToast";
+import { Fragment } from "react";
+
+type RootTemplateProps = {
+  children: React.ReactNode;
+};
+
+export default function RootTemplate({ children }: RootTemplateProps) {
+  return (
+    <Fragment>
+      <Fragment>{children}</Fragment>
+      <RedirectToast />
+    </Fragment>
+  );
+}

--- a/src/app/tickets/[ticketId]/page.tsx
+++ b/src/app/tickets/[ticketId]/page.tsx
@@ -1,4 +1,3 @@
-import RedirectToast from "@/components/RedirectToast";
 import TicketItem from "@/features/ticket/components/TicketItem";
 import { getTicket } from "@/features/ticket/queries/get-ticket";
 import { notFound } from "next/navigation";
@@ -23,7 +22,6 @@ const TicketPage = async ({ params }: TicketPageProps) => {
       <div className="flex justify-center animate-fade-in-from-top">
         <TicketItem ticket={ticket} isDetail />
       </div>
-      <RedirectToast />
     </Fragment>
   );
 };

--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -1,6 +1,5 @@
 import CardCompact from "@/components/CardCompact";
 import Heading from "@/components/Heading";
-import RedirectToast from "@/components/RedirectToast";
 import Spinner from "@/components/Spinner";
 import TicketList from "@/features/ticket/components/TicketList";
 import TicketUpsertForm from "@/features/ticket/components/TicketUpsertForm";
@@ -21,7 +20,6 @@ const TicketsPage = () => {
           <TicketList />
         </Suspense>
       </div>
-      <RedirectToast />
     </Fragment>
   );
 };

--- a/src/components/RedirectToast.tsx
+++ b/src/components/RedirectToast.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { deleteCookiesByKey, getCookieByKey } from "@/actions/cookies";
+import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { toast } from "sonner";
 
 const RedirectToast = () => {
+  const pathname = usePathname();
+
   useEffect(() => {
     const showCookieToast = async () => {
       const message = await getCookieByKey("toast");
@@ -16,7 +19,7 @@ const RedirectToast = () => {
     };
 
     showCookieToast();
-  }, []);
+  }, [pathname]);
   return null;
 };
 


### PR DESCRIPTION
Moved RedirectToast Component to template.tsx file  to rerender our toast  while ticket update and delete because the RedirectToast component in the page is error prone. Page in nextjs  renders when you navigate to them where in layout.ts  it renders the pages as children.